### PR TITLE
Oppdatere pdf grunnlag for opprett soknad, fjerne ol fra sanity portable tekst.

### DIFF
--- a/app/routes/opprett-soknad.tsx
+++ b/app/routes/opprett-soknad.tsx
@@ -12,6 +12,7 @@ import { opprettSoknad } from "~/models/opprett-soknad.server";
 import { SanityReadMore } from "~/sanity/components/SanityReadMore";
 import { portableTextToKomponenter } from "~/utils/sanity.utils";
 import { Route } from "./+types/opprett-soknad";
+import { lagSeksjonPayload } from "~/utils/seksjon.utils";
 
 const SEKSJON_ID = "startside";
 const SEKSJON_NAVN = "Startside";
@@ -64,14 +65,23 @@ export default function OpprettSoknadSide() {
     if (!vilkårTekst?.body) return;
 
     const bekreftVilkårKomponent: KomponentType = {
-      id: crypto.randomUUID(),
-      type: "forklarendeTekst",
+      id: "bekreftVilkår",
+      type: "envalg",
       label: bekreftVilkårTekst,
+      options: [
+        { value: "ja", label: "Ja" },
+        { value: "nei", label: "Nei" },
+      ],
     };
 
     const pdfGrunnlag = {
       navn: SEKSJON_NAVN,
-      spørsmål: [...portableTextToKomponenter(vilkårTekst.body), bekreftVilkårKomponent],
+      spørsmål: [
+        ...portableTextToKomponenter(vilkårTekst.body),
+        ...lagSeksjonPayload([{ ...bekreftVilkårKomponent, id: "bekreftVilkår" }], {
+          bekreftVilkår: form.transient.value().bekreftVilkår ? "ja" : "nei",
+        }),
+      ],
     };
 
     form.setValue("pdfGrunnlag", JSON.stringify(pdfGrunnlag));

--- a/app/utils/sanity.utils.ts
+++ b/app/utils/sanity.utils.ts
@@ -22,7 +22,9 @@ export function portableTextToKomponenter(body: TypedObject | TypedObject[]): Ko
       ];
     }
 
-    const html = toHTML([block]);
+    const rawHtml = toHTML([block]);
+    const html = rawHtml.replace(/<ol>/g, "<ul>").replace(/<\/ol>/g, "</ul>");
+
     if (html === "<p></p>") {
       return [];
     }


### PR DESCRIPTION
Sanity returnerer elementer i en array. Dersom det finnes ol vil det lages duplikater av ol element som fører til at vi får 

1. Tittel Tittel
Lorem ipsum
1. Tittel Tittel
Lorem ipsum
1. Tittel Tittel
Lorem ipsum

Litt dumt med at vi ikke får med oss ordered list, men informasjon er fortsatt der (det viktigste)