### PR TITLE
Bruk nedtrekksmenyer på Datokomponenten

### DIFF
--- a/app/components/spørsmål-komponent/Dato.tsx
+++ b/app/components/spørsmål-komponent/Dato.tsx
@@ -37,11 +37,11 @@ export function Dato({ props, formScope, ref }: IProps) {
         field.clearError();
         setError(undefined);
       }
-    },
+    }
   });
 
   return (
-    <DatePicker {...datepickerProps} key={props.id}>
+    <DatePicker {...datepickerProps} dropdownCaption={true} key={props.id}>
       <DatePicker.Input
         {...inputProps}
         ref={ref}


### PR DESCRIPTION
Da blir det enklere å velge riktig dato, siden man slipper å bla seg bakover måned for måned.
Det blir også likt som fra- og til-datovelgerne.