### PR TITLE
Redirect gamle varsel-URLer til nye

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -109,7 +109,7 @@ jobs:
     name: Deploy til dev-gcp
     permissions:
       id-token: "write"
-    if: github.actor != 'dependabot[bot]' || github.ref == 'refs/heads/main'
+    if: github.actor != 'dependabot[bot]' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/varsel-url-redirect'
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -109,7 +109,7 @@ jobs:
     name: Deploy til dev-gcp
     permissions:
       id-token: "write"
-    if: github.actor != 'dependabot[bot]' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/varsel-url-redirect'
+    if: github.actor != 'dependabot[bot]' || github.ref == 'refs/heads/main'
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -1,6 +1,8 @@
 ingresses:
   - https://arbeid.intern.dev.nav.no/dagpenger/dialog/soknad
   - https://arbeid.ansatt.dev.nav.no/dagpenger/dialog/soknad
+  - https://arbeid.intern.dev.nav.no/ny-dagpenger/dialog/soknad
+  - https://arbeid.ansatt.dev.nav.no/ny-dagpenger/dialog/soknad
 base_path: /dagpenger/dialog/soknad
 dekorator:
   url: https://dekoratoren.dev.nav.no/

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -1,5 +1,6 @@
 ingresses:
   - https://www.nav.no/dagpenger/dialog/soknad
+  - https://www.nav.no/ny-dagpenger/dialog/soknad
 base_path: "/dagpenger/dialog/soknad"
 dekorator:
   url: https://www.nav.no/dekoratoren

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -15,6 +15,9 @@ import { getEnv } from "./utils/env.utils";
 
 export const streamTimeout = 5_000;
 
+const GAMMEL_URL_PREFIX = "/ny-dagpenger/dialog/soknad";
+const NY_URL_PREFIX = "/dagpenger/dialog/soknad";
+
 if (getEnv("USE_MSW") === "true") {
   import("./mocks/mock-server").then(({ startMockServer }) => {
     startMockServer();
@@ -27,6 +30,15 @@ export default function handleRequest(
   responseHeaders: Headers,
   routerContext: EntryContext
 ) {
+  const url = new URL(request.url);
+  const shouldRedirect =
+    url.pathname === GAMMEL_URL_PREFIX || url.pathname.startsWith(`${GAMMEL_URL_PREFIX}/`);
+  if (shouldRedirect) {
+    const nyPath = NY_URL_PREFIX + url.pathname.slice(GAMMEL_URL_PREFIX.length);
+    const nyUrl = new URL(nyPath + url.search, url.origin);
+    return Response.redirect(nyUrl.toString(), 301);
+  }
+
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const userAgent = request.headers.get("user-agent");

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -12,11 +12,9 @@ import { renderToPipeableStream, type RenderToPipeableStreamOptions } from "reac
 import type { EntryContext } from "react-router";
 import { ServerRouter } from "react-router";
 import { getEnv } from "./utils/env.utils";
+import { isOutdatedBasePath, RedirectToUpdatedBasePath } from "./utils/redirect.utils";
 
 export const streamTimeout = 5_000;
-
-const GAMMEL_URL_PREFIX = "/ny-dagpenger/dialog/soknad";
-const NY_URL_PREFIX = "/dagpenger/dialog/soknad";
 
 if (getEnv("USE_MSW") === "true") {
   import("./mocks/mock-server").then(({ startMockServer }) => {
@@ -30,13 +28,8 @@ export default function handleRequest(
   responseHeaders: Headers,
   routerContext: EntryContext
 ) {
-  const url = new URL(request.url);
-  const shouldRedirect =
-    url.pathname === GAMMEL_URL_PREFIX || url.pathname.startsWith(`${GAMMEL_URL_PREFIX}/`);
-  if (shouldRedirect) {
-    const nyPath = NY_URL_PREFIX + url.pathname.slice(GAMMEL_URL_PREFIX.length);
-    const nyUrl = new URL(nyPath + url.search, url.origin);
-    return Response.redirect(nyUrl.toString(), 301);
+  if (isOutdatedBasePath(request)) {
+    return RedirectToUpdatedBasePath(new URL(request.url));
   }
 
   return new Promise((resolve, reject) => {
@@ -61,7 +54,7 @@ export default function handleRequest(
           resolve(
             new Response(stream, {
               headers: responseHeaders,
-              status: responseStatusCode,
+              status: responseStatusCode
             })
           );
 
@@ -78,7 +71,7 @@ export default function handleRequest(
           if (shellRendered) {
             console.log(error);
           }
-        },
+        }
       }
     );
 

--- a/app/utils/redirect.utils.ts
+++ b/app/utils/redirect.utils.ts
@@ -1,0 +1,18 @@
+const GAMMEL_INGRESS_PREFIX = "/ny-dagpenger/dialog/soknad";
+const URL_PREFIX = "/dagpenger/dialog/soknad";
+
+export function isOutdatedBasePath(request: Request): boolean {
+  const { pathname } = new URL(request.url);
+  return pathname === GAMMEL_INGRESS_PREFIX || pathname.startsWith(`${GAMMEL_INGRESS_PREFIX}/`);
+}
+
+export function createUpdatedBasePath(pathname: string): string {
+  return URL_PREFIX + pathname.slice(GAMMEL_INGRESS_PREFIX.length);
+}
+
+export function RedirectToUpdatedBasePath(url: URL): Response {
+  return Response.redirect(
+    new URL(createUpdatedBasePath(url.pathname) + url.search, url.origin).toString(),
+    301
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,39 @@
 import { reactRouter } from "@react-router/dev/vite";
 import path from "path";
-import { defineConfig } from "vite";
+import { defineConfig, type ViteDevServer } from "vite";
 import devtoolsJson from "vite-plugin-devtools-json";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { isOutdatedBasePath, createUpdatedBasePath } from "./app/utils/redirect.utils";
+
+const handleOutdatedBasePath = {
+  name: "handle-outdated-base-path",
+  configureServer(server: ViteDevServer) {
+    server.middlewares.use((req, res, next) => {
+      const url = new URL(req.url ?? "", "http://localhost");
+      const request = new Request(url);
+      if (isOutdatedBasePath(request)) {
+        res.writeHead(301, { Location: createUpdatedBasePath(url.pathname) + url.search });
+        res.end();
+        return;
+      }
+      next();
+    });
+  }
+};
 
 export default defineConfig({
   base:
     process.env.NODE_ENV === "production"
       ? "https://cdn.nav.no/teamdagpenger/dp-brukerdialog-frontend/client/"
       : "/dagpenger/dialog/soknad",
-  plugins: [reactRouter(), tsconfigPaths(), devtoolsJson()],
+  plugins: [reactRouter(), tsconfigPaths(), devtoolsJson(), handleOutdatedBasePath],
   build: {
     manifest: true,
-    sourcemap: process.env.NODE_ENV !== "production",
+    sourcemap: process.env.NODE_ENV !== "production"
   },
   resolve: {
     alias: {
-      "~": path.resolve(__dirname, "./app"),
-    },
-  },
+      "~": path.resolve(__dirname, "./app")
+    }
+  }
 });


### PR DESCRIPTION
Varselsystemet sendte lenker til /ny-dagpenger/dialog/soknad/* som ikke lenger eksisterer. Legger til de gamle stiene som NAIS- ingresses og redirecter 301 til /dagpenger/dialog/soknad/* i entry.server.tsx.