### PR TITLE
Bruk ingress for arbeidssøkerregisteret som matcher vår i dev

### DIFF
--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -21,7 +21,7 @@ faro_url: https://telemetry.ekstern.dev.nav.no/collect
 dp_soknad_orkestrator_url: http://dp-soknad-orkestrator
 dp_mellomlagring_url: http://dp-mellomlagring/v1/obo/mellomlagring
 arbeidssokerregisteret_url: https://oppslag-v2-arbeidssoekerregisteret.intern.dev.nav.no
-arbeidssokerregistrering_url: https://www.ansatt.dev.nav.no/arbeid/registrering
+arbeidssokerregistrering_url: https://arbeid.ansatt.dev.nav.no/arbeid/registrering
 dp_mine_dagpenger_url: https://arbeid.ansatt.dev.nav.no/arbeid/dagpenger/mine-dagpenger
 generell_innsending_url: https://arbeid.intern.dev.nav.no/gammel-dagpenger/dialog/generell-innsending/
 dp_soknad_url: http://dp-soknad/arbeid/dagpenger/soknadapi


### PR DESCRIPTION
Da skal session storage-løsningen for å sende folk tilbake til oss etter registrering funke.