### PR TITLE
Oppgrader ressurser

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -31,10 +31,9 @@ spec:
     cpuThresholdPercentage: 75
   resources:
     limits:
-      memory: 512Mi
+      memory: {{resources.limits.memory}}
     requests:
-      cpu: 100m
-      memory: 416Mi
+      memory: {{resources.requests.memory}}
   env:
     - name: SELF_URL
       value: "{{ingress}}"

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -10,6 +10,11 @@ dekorator:
 replicas:
   min: 1
   max: 2
+resources:
+  limits:
+    memory: 250Mi
+  requests:
+    memory: 160Mi
 loginservice:
   url: https://loginservice.dev.nav.no/login
 app_env: dev

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -8,6 +8,11 @@ dekorator:
 replicas:
   min: 4
   max: 6
+resources:
+  limits:
+    memory: 512Mi
+  requests:
+    memory: 416Mi
 loginservice:
   url: https://loginservice.nav.no/login
 app_env: prod


### PR DESCRIPTION
Fjerner limit pga dette fra nais dokumentasjonen:
> "limits.cpu is usually not needed, because your application will never be allowed to impact other processes running on the same CPU. If you need to do performance testing or similar activities, then setting limits.cpu might be useful to test how your application behaves when CPU constrained."

https://docs.nais.io/workloads/explanations/good-practices/?h=limit#set-reasonable-resource-requests-and-limits
