### PR TITLE
OmsorgForPleietrengendeINærFamilie skal trigge dokumentasjonskrav for del- og heltidssøkere

### DIFF
--- a/app/seksjon/reell-arbeidssøker/v1/ReellArbeidssøkerViewV1.tsx
+++ b/app/seksjon/reell-arbeidssøker/v1/ReellArbeidssøkerViewV1.tsx
@@ -23,6 +23,7 @@ import {
   kanIkkeJobbeHeltidOgDeltidAnnenSituasjon,
   kanIkkeJobbeHeltidOgDeltidDenAndreForeldrenJobberSkiftEllerLignendeOgAnsvarForBarnTilOgMed7KlasseEllerMedSpesielleBehov,
   kanIkkeJobbeHeltidOgDeltidEneansvarEllerDeltAnsvarForBarnUnder18ÅrMedSpesielleBehov,
+  kanIkkeJobbeHeltidOgDeltidOmsorgForPleietrengendeINærFamilie,
   kanIkkeJobbeHeltidOgDeltidRedusertHelse,
   kanIkkeJobbeHeltidOgDeltidSituasjonenSomGjelderDeg,
   kanIkkeJobbeIHeleNorgeAnnenSituasjon,
@@ -118,6 +119,7 @@ export function ReellArbeidssøkerViewV1() {
 
     const svarSomKanTriggesDokumentasjonskrav = [
       kanIkkeJobbeHeltidOgDeltidRedusertHelse,
+      kanIkkeJobbeHeltidOgDeltidOmsorgForPleietrengendeINærFamilie,
       kanIkkeJobbeHeltidOgDeltidEneansvarEllerDeltAnsvarForBarnUnder18ÅrMedSpesielleBehov,
       kanIkkeJobbeHeltidOgDeltidDenAndreForeldrenJobberSkiftEllerLignendeOgAnsvarForBarnTilOgMed7KlasseEllerMedSpesielleBehov,
       kanIkkeJobbeHeltidOgDeltidAnnenSituasjon,


### PR DESCRIPTION
Når en søker svarer 'nei' på spørsmålet om de kan jobbe del- og heltid, og velger 'Omsorgsansvar for pleietrengende i nær familie, for eksempel barn, foreldre eller ektefelle', ble det vist at dokumentasjonskrav ble trigget, men kravet dukket ikke opp dokumentasjons seksjonen så søkeren kunne laste opp dokumentasjon. Så dette fikser det!