### PR TITLE
Ikke deploy alle brancher til dev

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,7 +46,7 @@ jobs:
 
   build:
     name: Bygg
-    needs: [test]
+    needs: [ test ]
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
@@ -109,8 +109,8 @@ jobs:
     name: Deploy til dev-gcp
     permissions:
       id-token: "write"
-    if: github.actor != 'dependabot[bot]' || github.ref == 'refs/heads/main'
-    needs: [build]
+    if: github.ref == 'refs/heads/main'
+    needs: [ build ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
@@ -127,7 +127,7 @@ jobs:
     permissions:
       id-token: "write"
     if: github.ref == 'refs/heads/main'
-    needs: [build, deploy-dev]
+    needs: [ build, deploy-dev ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0


### PR DESCRIPTION
Det er litt upraktisk at ting deployes automatisk uten at vi ønsker det.