### PR TITLE
Stream fil direkte til dp-mellomlagring for å unngå minnelekkasje

### DIFF
--- a/app/routes/api.dokumentasjonskrav.$soknadId.$dokumentkravId.last-opp-fil.tsx
+++ b/app/routes/api.dokumentasjonskrav.$soknadId.$dokumentkravId.last-opp-fil.tsx
@@ -11,34 +11,52 @@ export async function action({ params, request }: ActionFunctionArgs) {
   invariant(params.soknadId, "Søknad ID er påkrevd");
   invariant(params.dokumentkravId, "Dokumentkrav ID er påkrevd");
 
-  const callId = uuidV4();
   const søknadId = params.soknadId;
   const dokumentkravId = params.dokumentkravId;
+  const callId = uuidV4();
 
-  const contentLength = Number(request.headers.get("Content-Length") ?? 0);
-  if (contentLength > MAX_FIL_STØRRELSE + MULTIPART_OVERHEAD) {
-    return new Response("Filen er for stor", { status: 413 });
+  const contentType = request.headers.get("Content-Type");
+
+  if (!contentType?.startsWith("multipart/form-data")) {
+    return new Response("Ugyldig opplastingsformat", { status: 400 });
+  }
+
+  const contentLengthHeader = request.headers.get("Content-Length");
+
+  if (contentLengthHeader) {
+    const contentLength = Number(contentLengthHeader);
+
+    if (!Number.isFinite(contentLength) || contentLength < 0) {
+      return new Response("Ugyldig Content-Length", { status: 400 });
+    }
+
+    if (contentLength > MAX_FIL_STØRRELSE + MULTIPART_OVERHEAD) {
+      return new Response("Filen er for stor", { status: 413 });
+    }
+  }
+
+  if (!request.body) {
+    return new Response("Mangler request body", { status: 400 });
   }
 
   try {
     const url = `${getEnv("DP_MELLOMLAGRING_URL")}/vedlegg/${søknadId}/${dokumentkravId}`;
-
     const onBehalfOfToken = await hentMellomlagringOboToken(request);
 
-    const respons = await fetch(url, {
+    const fetchInit = {
       method: "POST",
-      headers: {
+      headers: new Headers({
         Accept: "application/json",
         Authorization: `Bearer ${onBehalfOfToken}`,
-        "Content-Type": request.headers.get("Content-Type") ?? "",
+        "Content-Type": contentType,
         "X-Request-Id": callId,
-      },
+      }),
       body: request.body,
-      // @ts-expect-error — Node 24 krever duplex: "half" når body er en ReadableStream
+      signal: request.signal,
       duplex: "half",
-    });
+    } satisfies RequestInit & { duplex: "half" };
 
-    return respons;
+    return await fetch(url, fetchInit);
   } catch (error) {
     console.error(error);
 

--- a/app/routes/api.dokumentasjonskrav.$soknadId.$dokumentkravId.last-opp-fil.tsx
+++ b/app/routes/api.dokumentasjonskrav.$soknadId.$dokumentkravId.last-opp-fil.tsx
@@ -1,4 +1,3 @@
-import { parseFormData } from "@remix-run/form-data-parser";
 import { ActionFunctionArgs } from "react-router";
 import invariant from "tiny-invariant";
 import { v4 as uuidV4 } from "uuid";
@@ -6,33 +5,40 @@ import { hentMellomlagringOboToken } from "~/utils/auth.utils.server";
 import { MAX_FIL_STØRRELSE } from "~/utils/dokument.utils";
 import { getEnv } from "~/utils/env.utils";
 
+const MULTIPART_OVERHEAD = 10_240; // 10 KB buffer for boundary og part-headers
+
 export async function action({ params, request }: ActionFunctionArgs) {
   invariant(params.soknadId, "Søknad ID er påkrevd");
   invariant(params.dokumentkravId, "Dokumentkrav ID er påkrevd");
 
   const callId = uuidV4();
-  const søknadId = params.soknadId as string;
-  const dokumentkravId = params.dokumentkravId as string;
+  const søknadId = params.soknadId;
+  const dokumentkravId = params.dokumentkravId;
 
-  const formData = await parseFormData(request, { maxFileSize: MAX_FIL_STØRRELSE });
-  const fil = formData.get("fil") as File;
+  const contentLength = Number(request.headers.get("Content-Length") ?? 0);
+  if (contentLength > MAX_FIL_STØRRELSE + MULTIPART_OVERHEAD) {
+    return new Response("Filen er for stor", { status: 413 });
+  }
 
   try {
     const url = `${getEnv("DP_MELLOMLAGRING_URL")}/vedlegg/${søknadId}/${dokumentkravId}`;
+
     const onBehalfOfToken = await hentMellomlagringOboToken(request);
 
-    const body = new FormData();
-    body.append("fil", fil);
-
-    return await fetch(url, {
+    const respons = await fetch(url, {
       method: "POST",
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${onBehalfOfToken}`,
+        "Content-Type": request.headers.get("Content-Type") ?? "",
         "X-Request-Id": callId,
       },
-      body: body,
+      body: request.body,
+      // @ts-expect-error — Node 24 krever duplex: "half" når body er en ReadableStream
+      duplex: "half",
     });
+
+    return respons;
   } catch (error) {
     console.error(error);
 


### PR DESCRIPTION
Tidligere brukte last-opp-fil-ruten parseFormData() + new FormData() for å lese og re-encode multipart-requesten. Dette skapte to fulle kopier av filen i JS-heapen samtidig — én ved innlesing, én ved re-encoding — noe som forklarte den kontinuerlige RSS-veksten under opplasting.

Fixen streamer request.body direkte til dp-mellomlagring uten å bufre innholdet i Node. Content-Type-headeren (inkludert multipart boundary) videresendes uendret, og duplex: "half" er påkrevd av Node 24 når body er en ReadableStream.

En Content-Length-sjekk returnerer 413 tidlig dersom filen overstiger MAX_FIL_STØRRELSE + 10 KB (overhead for boundary og part-headers).

Resultat: RSS-gulv stabilt (~338 MB) mot kontinuerlig klatring (+100 MB per opplastingsbatch) med gammel kode.